### PR TITLE
Add MCP conformance testing workflow

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -28,7 +28,6 @@ jobs:
             "name": "http",
             "transport": "http",
             "start_command": "python -m mcp_starter.server --http --port 3000",
-            "server_url": "http://localhost:3000/mcp",
-            "health_endpoint": "/health"
+            "server_url": "http://localhost:3000/mcp"
           }
         ]

--- a/.github/workflows/remote-conformance.yml
+++ b/.github/workflows/remote-conformance.yml
@@ -1,0 +1,51 @@
+# Remote Conformance Test
+#
+# This workflow tests against a deployed MCP server endpoint.
+# 
+# To use this workflow:
+# 1. Deploy your MCP server to a hosting service
+# 2. Add the following repository secrets:
+#    - MCP_REMOTE_URL: Your deployed server's MCP endpoint (e.g., https://my-mcp-server.example.com/mcp)
+# 3. Uncomment the workflow below
+#
+# Example: Testing a server deployed to Railway, Fly.io, etc.
+
+name: Remote Conformance Test
+
+on:
+  # Run on schedule to catch environment drift
+  # schedule:
+  #   - cron: '0 0 * * 0'  # Weekly on Sunday
+  
+  # Run on releases to validate deployed versions
+  push:
+    tags: ['v*']
+  
+  # Manual trigger for on-demand testing
+  workflow_dispatch:
+    inputs:
+      server_url:
+        description: 'MCP Server URL to test'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  remote-conformance:
+    # Only run if remote URL is configured
+    if: vars.MCP_REMOTE_URL != '' || github.event.inputs.server_url != ''
+    uses: SamMorrowDrums/mcp-conformance-action/.github/workflows/conformance.yml@main
+    with:
+      # No build needed for remote testing
+      install_command: "echo 'Testing remote server'"
+      
+      configurations: |
+        [
+          {
+            "name": "remote-production",
+            "transport": "http",
+            "server_url": "${{ github.event.inputs.server_url || vars.MCP_REMOTE_URL }}"
+          }
+        ]


### PR DESCRIPTION
## Summary

Adds conformance testing to detect behavioral changes in the MCP server between versions.

## What's Included

- New `.github/workflows/conformance.yml` workflow
- Uses the reusable workflow from [SamMorrowDrums/mcp-conformance-action](https://github.com/SamMorrowDrums/mcp-conformance-action)

## How It Works

The conformance test:
1. Builds both the current branch and the merge-base (common ancestor with main)
2. Sends MCP protocol messages to both versions (initialize, tools/list, resources/list, prompts/list)
3. Compares responses and generates a detailed diff report
4. Shows results in the GitHub Job Summary

## Triggers

- **Pull requests to main**: Review changes before merge
- **Push to main**: Validate after merge
- **Version tags (v*)**: Compare releases